### PR TITLE
Fix form validation message translations

### DIFF
--- a/src/pages/Auth/Signin/components/SigninForm.tsx
+++ b/src/pages/Auth/Signin/components/SigninForm.tsx
@@ -1,9 +1,9 @@
 import { useState } from 'react';
-import { InferType, object, string } from 'yup';
+import { object, string } from 'yup';
 import { useNavigate } from 'react-router-dom';
 import { useForm } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { t } from 'i18next';
+import { useTranslation } from 'react-i18next';
 
 import { cn } from 'common/utils/css';
 import { BaseComponentProps } from 'common/utils/types';
@@ -14,20 +14,13 @@ import Alert from 'common/components/Alert/Alert';
 import Button from 'common/components/Button/Button';
 
 /**
- * Signin form validation schema.
- */
-const validationSchema = object({
-  password: string().required(t('validation.required')),
-  username: string()
-    .required(t('validation.required'))
-    .max(30, t('validation.max', { count: 30 })),
-});
-
-/**
  * Signin form values.
  */
 
-type SigninFormValues = InferType<typeof validationSchema>;
+type SigninFormValues = {
+  username: string;
+  password: string;
+};
 
 /**
  * The `SigninForm` component renders a form for user authentication.
@@ -44,6 +37,17 @@ const SigninForm = ({ className, testId = 'form-signin' }: BaseComponentProps): 
   const [error, setError] = useState<string>('');
   const { mutate: signin } = useSignin();
   const navigate = useNavigate();
+  const { t } = useTranslation();
+
+  /**
+   * Signin form validation schema.
+   */
+  const validationSchema = object({
+    password: string().required(t('validation.required')),
+    username: string()
+      .required(t('validation.required'))
+      .max(30, t('validation.max', { count: 30 })),
+  });
 
   /**
    * Initialize management of the form.

--- a/src/pages/Tasks/components/Form/TaskForm.tsx
+++ b/src/pages/Tasks/components/Form/TaskForm.tsx
@@ -1,7 +1,7 @@
-import { boolean, InferType, number, object, string } from 'yup';
-import { t } from 'i18next';
+import { boolean, number, object, string } from 'yup';
 import { useForm } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
+import { useTranslation } from 'react-i18next';
 
 import { cn } from 'common/utils/css';
 import { BaseComponentProps } from 'common/utils/types';
@@ -11,20 +11,9 @@ import Button from 'common/components/Button/Button';
 import Toggle from 'common/components/Form/Toggle';
 
 /**
- * Task form validation schema.
- */
-const validationSchema = object({
-  userId: number().required(t('validation.required')),
-  title: string()
-    .required(t('validation.required'))
-    .max(100, t('validation.max', { count: 100 })),
-  completed: boolean().required(t('validation.required')).default(false),
-});
-
-/**
  * Task form values.
  */
-export type TaskFormValues = InferType<typeof validationSchema>;
+export type TaskFormValues = Pick<Task, 'userId' | 'title' | 'completed'>;
 
 /**
  * Properties for the `TaskForm` component.
@@ -42,12 +31,8 @@ export interface TaskFormProps extends BaseComponentProps {
 
 /**
  * The `TaskForm` component renders a form for creating and updating `Task` objects.
- *
- * Upon successful submission, navigates back to the previous page.
- *
- * Upon cancellation, navigates back to the previous page.
- *
- * Upon error, displays a message.
+ * Form submission and cancellation functions are supplied as props and
+ * will be invoked when the respective form button is clicked.
  *
  * @param {TaskFormProps} props - Component properties.
  * @returns JSX
@@ -59,6 +44,19 @@ const TaskForm = ({
   task,
   testId = 'task-form',
 }: TaskFormProps): JSX.Element => {
+  const { t } = useTranslation();
+
+  /**
+   * Task form validation schema.
+   */
+  const validationSchema = object({
+    userId: number().required(t('validation.required')),
+    title: string()
+      .required(t('validation.required'))
+      .max(100, t('validation.max', { count: 100 })),
+    completed: boolean().required(t('validation.required')).default(false),
+  });
+
   /**
    * Initializes management of the form.
    */


### PR DESCRIPTION
:loudspeaker: **Instructions**

- Begin with a **DRAFT** pull request.
- Follow _italicized instructions_ to add detail to assist the reviewers.
- After completing all checklist items, change the pull request to **READY**.

---

### :wrench: Change Summary

_Describe the changes included in this pull request. [Link](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to the associated GitHub issue(s)._

- fixes #49 
- Fixed the translation (i18n) of form validation messages so that if a user changes the language while viewing a form, the validation messages reflect the language change.

### :memo: Checklist

_Pull request authors must complete the following tasks before marking the PR as ready to review._

- [x] Complete a self-review of changes
- [x] Unit tests have been created or updated
- [x] The code is free of [new] lint errors and warnings
- [x] Update storybook stories as needed
- [x] Update project documentation as needed, README, JSDoc, etc.

### :test_tube: Steps to Test

_Describe the process to test the changes in this pull request._

1. Go to the landing page. 
2. Set the language to English.
3. View the Sign in page.
4. Trigger a validation message (it should be in English.)
5. Change the language to Spanish.
6. Trigger a new validation message (it should be in Spanish.)

### :link: Additional Information

_Optionally, provide additional details, screenshots, or URLs that may assist the reviewer._

- [...]
