### PR TITLE
Lazy load components

### DIFF
--- a/src/common/components/Loader/LoaderSuspense.tsx
+++ b/src/common/components/Loader/LoaderSuspense.tsx
@@ -1,0 +1,26 @@
+import { PropsWithChildren, Suspense } from 'react';
+
+import LoaderSpinner from './LoaderSpinner';
+
+/**
+ * The `LoaderSuspense` component renders an animated spinning loader. Typically used
+ * in the `Router` to display loading state when dynamic imports are loading.
+ */
+const LoaderSuspense = ({ children }: PropsWithChildren): JSX.Element => {
+  return (
+    <Suspense
+      fallback={
+        <div
+          className="flex h-[50vh] items-center justify-center"
+          data-testid="loader-suspense-fallback"
+        >
+          <LoaderSpinner text="Loading..." testId="loader-suspense-spinner" />
+        </div>
+      }
+    >
+      {children}
+    </Suspense>
+  );
+};
+
+export default LoaderSuspense;

--- a/src/common/components/Loader/__tests__/LoaderSuspense.test.tsx
+++ b/src/common/components/Loader/__tests__/LoaderSuspense.test.tsx
@@ -1,0 +1,22 @@
+import { lazy } from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { render, screen } from 'test/test-utils';
+const Text = lazy(() => import('common/components/Text/Text'));
+
+import LoaderSuspense from '../LoaderSuspense';
+
+describe('LoaderSuspense', () => {
+  it('should render successfully', async () => {
+    // ARRANGE
+    render(
+      <LoaderSuspense>
+        <Text testId="lazy-component" />
+      </LoaderSuspense>,
+    );
+    await screen.findByTestId('loader-suspense-fallback');
+
+    // ASSERT
+    expect(screen.getByTestId('loader-suspense-fallback')).toBeDefined();
+  });
+});

--- a/src/common/components/Router/Router.tsx
+++ b/src/common/components/Router/Router.tsx
@@ -1,38 +1,46 @@
+import { lazy } from 'react';
 import { Navigate, RouteObject, createBrowserRouter } from 'react-router-dom';
 
+import { withSuspense } from 'common/utils/suspense';
 import StandardLayout from 'common/components/Layout/StandardLayout';
 import ErrorPage from 'pages/Error/ErrorPage';
 import PrivateOutlet from './PrivateOutlet';
+
+// Landing Page Family
 import LandingPage from 'pages/Landing/LandingPage';
 
 // Auth Page Family
-import SigninPage from 'pages/Auth/Signin/SigninPage';
-import SignoutPage from 'pages/Auth/Signout/SignoutPage';
+const SigninPage = lazy(() => import('pages/Auth/Signin/SigninPage'));
+const SignoutPage = lazy(() => import('pages/Auth/Signout/SignoutPage'));
 
 // Settings Page Family
-import SettingsPage from 'pages/Settings/SettingsPage';
-import AppearanceSettings from 'pages/Settings/components/AppearanceSettings';
+const SettingsPage = lazy(() => import('pages/Settings/SettingsPage'));
+const AppearanceSettings = lazy(() => import('pages/Settings/components/AppearanceSettings'));
 
 // Components Page Family
-import ComponentsPage from 'pages/Components/ComponentsPage';
-import AlertComponents from 'pages/Components/components/AlertComponents';
-import AvatarComponents from 'pages/Components/components/AvatarComponents';
-import BadgeComponents from 'pages/Components/components/BadgeComponents';
-import BreadcrumbsComponents from 'pages/Components/components/BreadcrumbsComponents';
-import ButtonComponents from 'pages/Components/components/ButtonComponents';
-import CardComponents from 'pages/Components/components/CardComponents';
-import DialogComponents from 'pages/Components/components/DialogComponents';
-import DropdownComponents from 'pages/Components/components/DropdownComponents';
-import SearchInputComponents from 'pages/Components/components/SearchInputComponents';
-import TabsComponents from 'pages/Components/components/TabsComponents';
-import TextComponents from 'pages/Components/components/TextComponents';
+const ComponentsPage = lazy(() => import('pages/Components/ComponentsPage'));
+const AlertComponents = lazy(() => import('pages/Components/components/AlertComponents'));
+const AvatarComponents = lazy(() => import('pages/Components/components/AvatarComponents'));
+const BadgeComponents = lazy(() => import('pages/Components/components/BadgeComponents'));
+const BreadcrumbsComponents = lazy(
+  () => import('pages/Components/components/BreadcrumbsComponents'),
+);
+const ButtonComponents = lazy(() => import('pages/Components/components/ButtonComponents'));
+const CardComponents = lazy(() => import('pages/Components/components/CardComponents'));
+const DialogComponents = lazy(() => import('pages/Components/components/DialogComponents'));
+const DropdownComponents = lazy(() => import('pages/Components/components/DropdownComponents'));
+const SearchInputComponents = lazy(
+  () => import('pages/Components/components/SearchInputComponents'),
+);
+const TabsComponents = lazy(() => import('pages/Components/components/TabsComponents'));
+const TextComponents = lazy(() => import('pages/Components/components/TextComponents'));
 
 // Tasks Page Family
-import TasksPage from 'pages/Tasks/TasksPage';
-import TaskListLayout from 'pages/Tasks/components/TaskListLayout';
-import TaskDetailLayout from 'pages/Tasks/components/TaskDetailLayout';
-import TaskAdd from 'pages/Tasks/components/Add/TaskAdd';
-import TaskEdit from 'pages/Tasks/components/Edit/TaskEdit';
+const TasksPage = lazy(() => import('pages/Tasks/TasksPage'));
+const TaskListLayout = lazy(() => import('pages/Tasks/components/TaskListLayout'));
+const TaskDetailLayout = lazy(() => import('pages/Tasks/components/TaskDetailLayout'));
+const TaskAdd = lazy(() => import('pages/Tasks/components/Add/TaskAdd'));
+const TaskEdit = lazy(() => import('pages/Tasks/components/Edit/TaskEdit'));
 
 /**
  * The React Router configuration. An array of `RouteObject`.
@@ -54,11 +62,11 @@ export const routes: RouteObject[] = [
           { index: true, element: <Navigate to="signin" replace /> },
           {
             path: 'signin',
-            element: <SigninPage />,
+            element: withSuspense(<SigninPage />),
           },
           {
             path: 'signout',
-            element: <SignoutPage />,
+            element: withSuspense(<SignoutPage />),
           },
         ],
       },
@@ -68,7 +76,7 @@ export const routes: RouteObject[] = [
           { index: true, element: <Navigate to="components" replace /> },
           {
             path: 'components',
-            element: <ComponentsPage />,
+            element: withSuspense(<ComponentsPage />),
             children: [
               {
                 index: true,
@@ -76,47 +84,47 @@ export const routes: RouteObject[] = [
               },
               {
                 path: 'alert',
-                element: <AlertComponents />,
+                element: withSuspense(<AlertComponents />),
               },
               {
                 path: 'avatar',
-                element: <AvatarComponents />,
+                element: withSuspense(<AvatarComponents />),
               },
               {
                 path: 'badge',
-                element: <BadgeComponents />,
+                element: withSuspense(<BadgeComponents />),
               },
               {
                 path: 'breadcrumbs',
-                element: <BreadcrumbsComponents />,
+                element: withSuspense(<BreadcrumbsComponents />),
               },
               {
                 path: 'button',
-                element: <ButtonComponents />,
+                element: withSuspense(<ButtonComponents />),
               },
               {
                 path: 'card',
-                element: <CardComponents />,
+                element: withSuspense(<CardComponents />),
               },
               {
                 path: 'dialog',
-                element: <DialogComponents />,
+                element: withSuspense(<DialogComponents />),
               },
               {
                 path: 'dropdown',
-                element: <DropdownComponents />,
+                element: withSuspense(<DropdownComponents />),
               },
               {
                 path: 'search-input',
-                element: <SearchInputComponents />,
+                element: withSuspense(<SearchInputComponents />),
               },
               {
                 path: 'tabs',
-                element: <TabsComponents />,
+                element: withSuspense(<TabsComponents />),
               },
               {
                 path: 'text',
-                element: <TextComponents />,
+                element: withSuspense(<TextComponents />),
               },
             ],
           },
@@ -129,7 +137,7 @@ export const routes: RouteObject[] = [
           { index: true, element: <Navigate to="tasks" replace /> },
           {
             path: 'settings',
-            element: <SettingsPage />,
+            element: withSuspense(<SettingsPage />),
             children: [
               {
                 index: true,
@@ -137,32 +145,32 @@ export const routes: RouteObject[] = [
               },
               {
                 path: 'appearance',
-                element: <AppearanceSettings />,
+                element: withSuspense(<AppearanceSettings />),
               },
             ],
           },
           {
             path: 'tasks',
-            element: <TasksPage />,
+            element: withSuspense(<TasksPage />),
             children: [
               {
                 index: true,
-                element: <TaskListLayout />,
+                element: withSuspense(<TaskListLayout />),
               },
               {
                 path: 'add',
-                element: <TaskAdd />,
+                element: withSuspense(<TaskAdd />),
               },
               {
                 path: ':taskId',
                 children: [
                   {
                     index: true,
-                    element: <TaskDetailLayout />,
+                    element: withSuspense(<TaskDetailLayout />),
                   },
                   {
                     path: 'edit',
-                    element: <TaskEdit />,
+                    element: withSuspense(<TaskEdit />),
                   },
                 ],
               },

--- a/src/common/utils/__tests__/suspense.test.tsx
+++ b/src/common/utils/__tests__/suspense.test.tsx
@@ -1,0 +1,18 @@
+import { lazy } from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { render, screen } from 'test/test-utils';
+const Text = lazy(() => import('common/components/Text/Text'));
+
+import { withSuspense } from '../suspense';
+
+describe('withSuspense', () => {
+  it('should return LoaderSuspense', async () => {
+    // ARRANGE
+    render(withSuspense(<Text testId="lazy-component">Test</Text>));
+    await screen.findByTestId('loader-suspense-fallback');
+
+    // ASSERT
+    expect(screen.getByTestId('loader-suspense-fallback')).toBeDefined();
+  });
+});

--- a/src/common/utils/suspense.tsx
+++ b/src/common/utils/suspense.tsx
@@ -1,0 +1,12 @@
+import { ReactNode } from 'react';
+
+import LoaderSuspense from 'common/components/Loader/LoaderSuspense';
+
+/**
+ * Helper function which wraps the supplied `children` with the `LoaderSuspense`
+ * component.
+ * @param children - The `ReactNode` to be rendered when not in suspense.
+ * @returns JSX
+ * @see {@link https://react.dev/reference/react/lazy}
+ */
+export const withSuspense = (children: ReactNode) => <LoaderSuspense>{children}</LoaderSuspense>;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -34,4 +34,23 @@ export default defineConfig({
     mockReset: true,
     setupFiles: ['./vitest.setup.ts'],
   },
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks: (id) => {
+          if (id.indexOf('node_modules') > -1) {
+            if (id.indexOf('@codemirror') > -1) {
+              return 'codemirror';
+            }
+            if (id.indexOf('@fortawesome') > -1) {
+              return 'fortawesome';
+            }
+            if (id.indexOf('mime-db') > -1) {
+              return 'mime-db';
+            }
+          }
+        },
+      },
+    },
+  },
 });


### PR DESCRIPTION
:loudspeaker: **Instructions**

- Begin with a **DRAFT** pull request.
- Follow _italicized instructions_ to add detail to assist the reviewers.
- After completing all checklist items, change the pull request to **READY**.

---

### :wrench: Change Summary

_Describe the changes included in this pull request. [Link](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to the associated GitHub issue(s)._

- fixes #69 
- Updated the `Router` to lazy load routed components.
- Added the `LoaderSuspense` which displays a loader while the lazily loaded import is resolving.
- Add the `withSuspense` utility function to simplify wrapping components with the suspense loader within the router configuration.

### :memo: Checklist

_Pull request authors must complete the following tasks before marking the PR as ready to review._

- [x] Complete a self-review of changes
- [x] Unit tests have been created or updated
- [x] The code is free of [new] lint errors and warnings
- [x] Update storybook stories as needed
- [x] Update project documentation as needed, README, JSDoc, etc.

### :test_tube: Steps to Test

_Describe the process to test the changes in this pull request._

1. Complete regression test.
2. Reload the app. In dev tools, set the network speed to "Fast 4G". Navigate through the site and notice the `LoaderSuspense` rendering while dynamic imports are loading.  Note that the loader is displayed only the first time the import is loaded; subsequent uses of that component are rendered instantaneously.

### :link: Additional Information

_Optionally, provide additional details, screenshots, or URLs that may assist the reviewer._

- [...]
